### PR TITLE
Add missing doc for input button tutorial

### DIFF
--- a/Resources/doc/tutorials/input-button.md
+++ b/Resources/doc/tutorials/input-button.md
@@ -4,6 +4,15 @@ How to add a button that open the File manager to fill out an input field with t
 
 > This example uses bootstrap
 
+### Add following configuration
+
+```yaml
+# app/config/config.yml
+artgris_file_manager:
+    conf:
+        tiny:
+            dir: "../web/uploads"
+```
 
 ### Create input and button
 


### PR DESCRIPTION
This needed a clarification for the 'conf' parameter.
I was facing this error `Please define a "dir" parameter in your config.yml` despite having this configuration :

```yaml
artgris_file_manager:
    conf:
        default:
            dir: "%files_directory%"
```

I needed :

```yaml
artgris_file_manager:
    conf:
        default:
            dir: "%files_directory%"
        tiny:
            dir: "%files_directory%"
```