### PR TITLE
Router interface

### DIFF
--- a/Helpers/FileManager.php
+++ b/Helpers/FileManager.php
@@ -2,10 +2,10 @@
 
 namespace Artgris\Bundle\FileManagerBundle\Helpers;
 
-use Symfony\Bundle\FrameworkBundle\Routing\Router;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Routing\RouterInterface;
 
 /**
  * @author Arthur Gribet <a.gribet@gmail.com>
@@ -27,12 +27,12 @@ class FileManager
      * @param $queryParameters
      * @param $configuration
      * @param $kernelRoute
-     * @param Router $router
+     * @param RouterInterface $router
      * @param $webDir
      *
      * @internal param $basePath
      */
-    public function __construct($queryParameters, $configuration, $kernelRoute, Router $router, $webDir)
+    public function __construct($queryParameters, $configuration, $kernelRoute, RouterInterface $router, $webDir)
     {
         $this->queryParameters = $queryParameters;
         $this->configuration = $configuration;
@@ -205,7 +205,7 @@ class FileManager
     }
 
     /**
-     * @return Router
+     * @return RouterInterface
      */
     public function getRouter()
     {
@@ -213,9 +213,9 @@ class FileManager
     }
 
     /**
-     * @param Router $router
+     * @param RouterInterface $router
      */
-    public function setRouter(Router $router)
+    public function setRouter(RouterInterface $router)
     {
         $this->router = $router;
     }

--- a/Service/FileTypeService.php
+++ b/Service/FileTypeService.php
@@ -4,8 +4,8 @@ namespace Artgris\Bundle\FileManagerBundle\Service;
 
 use Artgris\Bundle\FileManagerBundle\Helpers\FileManager;
 use SplFileInfo;
-use Symfony\Bundle\FrameworkBundle\Routing\Router;
 use Symfony\Component\Asset\Packages;
+use Symfony\Component\Routing\RouterInterface;
 
 class FileTypeService
 {
@@ -15,17 +15,17 @@ class FileTypeService
     ];
 
     /**
-     * @var Router
+     * @var RouterInterface
      */
     private $router;
 
     /**
      * FileTypeService constructor.
      *
-     * @param Router   $router
+     * @param RouterInterface $router
      * @param Packages $packages
      */
-    public function __construct(Router $router)
+    public function __construct(RouterInterface $router)
     {
         $this->router = $router;
     }

--- a/Twig/OrderExtension.php
+++ b/Twig/OrderExtension.php
@@ -3,7 +3,7 @@
 namespace Artgris\Bundle\FileManagerBundle\Twig;
 
 use Artgris\Bundle\FileManagerBundle\Helpers\FileManager;
-use Symfony\Component\Routing\Router;
+use Symfony\Component\Routing\RouterInterface;
 
 class OrderExtension extends \Twig_Extension
 {
@@ -11,16 +11,16 @@ class OrderExtension extends \Twig_Extension
     const DESC = 'desc';
 
     /**
-     * @var Router
+     * @var RouterInterface
      */
     private $router;
 
     /**
      * OrderExtension constructor.
      *
-     * @param Router $router
+     * @param RouterInterface $router
      */
-    public function __construct(Router $router)
+    public function __construct(RouterInterface $router)
     {
         $this->router = $router;
     }


### PR DESCRIPTION
Having this error by using Symfony CMF ChainRouter:
Type error: Argument 1 passed to Artgris\Bundle\FileManagerBundle\Twig\OrderExtension::__construct() must be an instance of Symfony\Component\Routing\Router, instance of Symfony\Cmf\Component\Routing\ChainRouter

I changed the injected type params from Router to RouterInterface to make it work.