### PR TITLE
fix - used RegExp instead of URL to fix IE CKEditor integration (#48)

### DIFF
--- a/Resources/public/js/manager.js
+++ b/Resources/public/js/manager.js
@@ -199,8 +199,8 @@ $(function () {
     // Module CKEditor
     if (moduleName === 'ckeditor') {
         $('#form-multiple-delete').on('click', '.select', function () {
-            var url = new URL(window.location.href);
-            var funcNum = url.searchParams.get("CKEditorFuncNum");
+            var regex = new RegExp("[\\?&]CKEditorFuncNum=([^&#]*)");
+            var funcNum = regex.exec(location.search)[1];
             var fileUrl = $(this).attr("data-path");
             window.opener.CKEDITOR.tools.callFunction(funcNum, fileUrl);
             window.close();


### PR DESCRIPTION
Removed URL as it is not supported by IE and used RegExp instead. This was tested in IE11.