### PR TITLE
Fix PHP Notice: Trying to access array offset on value of type null

### DIFF
--- a/Helpers/UploadHandler.php
+++ b/Helpers/UploadHandler.php
@@ -524,7 +524,7 @@ class UploadHandler
             $name = $this->upcount_name($name);
         }
         // Keep an existing filename if this is part of a chunked upload:
-        $uploaded_bytes = $this->fix_integer_overflow((int) isset($content_range[1]) ? $content_range[1] : null);
+        $uploaded_bytes = $this->fix_integer_overflow((int) ($content_range[1] ?? null));
         while (is_file($this->get_upload_path($name))) {
             if ($uploaded_bytes === $this->get_file_size(
                     $this->get_upload_path($name))

--- a/Helpers/UploadHandler.php
+++ b/Helpers/UploadHandler.php
@@ -524,7 +524,7 @@ class UploadHandler
             $name = $this->upcount_name($name);
         }
         // Keep an existing filename if this is part of a chunked upload:
-        $uploaded_bytes = $this->fix_integer_overflow((int) $content_range[1]);
+        $uploaded_bytes = $this->fix_integer_overflow((int) isset($content_range[1]) ? $content_range[1] : null);
         while (is_file($this->get_upload_path($name))) {
             if ($uploaded_bytes === $this->get_file_size(
                     $this->get_upload_path($name))


### PR DESCRIPTION
Fix PHP array access on a null when content-range header is not set.

https://www.php.net/manual/de/migration74.incompatible.php#migration74.incompatible.core.non-array-access