### PR TITLE
[Fix] Upload : Trying to access array offset on value of type null

### DIFF
--- a/Helpers/UploadHandler.php
+++ b/Helpers/UploadHandler.php
@@ -524,7 +524,9 @@ class UploadHandler
             $name = $this->upcount_name($name);
         }
         // Keep an existing filename if this is part of a chunked upload:
-        $uploaded_bytes = $this->fix_integer_overflow((int) $content_range[1]);
+        if (isset($content_range)) {
+            $uploaded_bytes = $this->fix_integer_overflow((int) $content_range[1]);
+        }
         while (is_file($this->get_upload_path($name))) {
             if ($uploaded_bytes === $this->get_file_size(
                     $this->get_upload_path($name))


### PR DESCRIPTION
Fix : Notice: Trying to access array offset on value of type null
This happens because $content_range is null or the index does not exist. Previous versions of PHP may have been less strict on such mistakes and silently swallowed the error / notice while 7.4 does not do this anymore.