### PR TITLE
Update composer-installers-extender dependency

### DIFF
--- a/Tests/Controller/EmptyConfTest.php
+++ b/Tests/Controller/EmptyConfTest.php
@@ -15,7 +15,7 @@ class EmptyConfTest extends AbstractTestCase
     public function testUndefinedConfManager()
     {
         $this->getManagerPage();
-        $this->assertContains(
+        $this->assertStringContainsString(
             'Please define a &quot;dir&quot; or a &quot;service&quot; parameter in your config.yml',
             $this->client->getResponse()->getContent()
         );

--- a/Tests/Controller/UnExistDirConfTest.php
+++ b/Tests/Controller/UnExistDirConfTest.php
@@ -15,7 +15,7 @@ class UnExistDirConfTest extends AbstractTestCase
     public function testUnExistDirConfManager()
     {
         $this->getManagerPage();
-        $this->assertContains(
+        $this->assertStringContainsString(
             'Directory does not exist.',
             $this->client->getResponse()->getContent()
         );

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "symfony/validator": "^4.4|^5.0",
     "symfony/asset": "^4.4|^5.0",
     "symfony/expression-language": "^4.4|^5.0",
-    "oomphinc/composer-installers-extender": "^1.1"
+    "oomphinc/composer-installers-extender": "^1.1|^2.0"
   },
   "require-dev": {
     "symfony/phpunit-bridge": "^4.3.5|^5.0",


### PR DESCRIPTION
- Add support `oomphinc/composer-installers-extender` v2 for Composer 2
- Fix some deprecations in tests to ensure PHPUnit 9 support

PS: I would be very grateful if this PR could be counted for Hackoberfest ^^