### PR TITLE
Fix path directive which results in an error

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Create a folder **uploads** in **public**.
 artgris_file_manager:
     conf:
         default:
-            dir: "../public/uploads"
+            dir: '%kernel.project_dir%/public/uploads'
 ```
 
 Browse the `/manager/?conf=default` URL and you'll get access to your 


### PR DESCRIPTION
When following the docs a 'directory cannot be found' error is thrown even though the directory exists. Using the project_dir parameter from the kernel is a safer way to access the file directory.