### PR TITLE
Fix translation for 'refresh'

### DIFF
--- a/Resources/translations/messages.nl.yml
+++ b/Resources/translations/messages.nl.yml
@@ -19,7 +19,7 @@ folder:
     unauthorized: Map bestaat niet meer of u bent niet bevoegd om deze pagina te openen.
 button:
   cancel: ANULEREN
-  refresh: Verfrissen
+  refresh: Verversen
   parent: Parent
   save: OPSLAAN
   add:


### PR DESCRIPTION
'Verfrissen' means something like 'refreshing' in Dutch, there for 'Verversen' is more appropriate to update the current state.