### PR TITLE
Feature to show or hide file counts

### DIFF
--- a/Controller/ManagerController.php
+++ b/Controller/ManagerController.php
@@ -453,8 +453,11 @@ class ManagerController extends AbstractController
             $queryParametersRoute = $queryParameters;
             unset($queryParametersRoute['route']);
 
-            $filesNumber = $this->retrieveFilesNumber($directory->getPathname(), $fileManager->getRegex());
-            $fileSpan = $filesNumber > 0 ? " <span class='label label-default'>{$filesNumber}</span>" : '';
+            $fileSpan = '';
+            if (true === $fileManager->getConfiguration()['show_file_count']) {
+                $filesNumber = $this->retrieveFilesNumber($directory->getPathname(), $fileManager->getRegex());
+                $fileSpan = $filesNumber > 0 ? " <span class='label label-default'>{$filesNumber}</span>" : '';
+            }
 
             $directoriesList[] = [
                 'text' => $directory->getFilename().$fileSpan,

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -30,6 +30,7 @@ class Configuration implements ConfigurationInterface
                             ->scalarNode('dir')->end()
                             ->enumNode('type')->values(['file', 'image', 'media'])->end()
                             ->booleanNode('tree')->end()
+                            ->booleanNode('show_file_count')->defaultValue(true)->end()
                             ->scalarNode('twig_extension')->end()
                             ->booleanNode('cachebreaker')->defaultValue(true)->end()
                             ->enumNode('view')->values(['thumbnail', 'list'])->defaultValue('list')->end()

--- a/Resources/doc/book/1-basic-configuration.md
+++ b/Resources/doc/book/1-basic-configuration.md
@@ -165,6 +165,14 @@ artgris_file_manager:
 
 Adding a cachebreaker ?time=RANDOM_NUMBER or & &time=RANDOM_NUMBER at the end of the images (preview) url. It's removed if you have used "twig_extension" option.
 
+## `show_file_count` to show the number of files per directory in the file browser tree
+
+| Option            | Type     | Required  | Default value |
+|:------------------|:--------:|:--------:|:-------------:|
+| `show_file_count` | `bool` |  False   | True |
+
+Having a large number of files in a (sub-)directory can have a huge impact on performance, setting this to false will improve the performance at the cost of the display of files per directory
+
 ## `upload` A non-exhaustive  configuration of the File Upload widget [blueimp/jQuery-File-Upload](https://github.com/blueimp/jQuery-File-Upload)
 > [Exhaustive options](https://github.com/blueimp/jQuery-File-Upload/blob/master/server/php/UploadHandler.php) can only be defined with [The service configuration](2-service-configuration.md)
 


### PR DESCRIPTION
When running my xDebug profiler on the code from my project I noticed that counting the number of files took 49.2% of the total time of the request in my test environment. While a huge optimization would take quite a lot of time there was a way to make the request double as fast by only hiding the file count per directory which might also pass as a nice feature to have a cleaner interface.
