### PR TITLE
Fixed crashing app when image (filepath) has been set as null

### DIFF
--- a/Service/FileTypeService.php
+++ b/Service/FileTypeService.php
@@ -66,7 +66,7 @@ class FileTypeService {
         return $accept;
     }
 
-    public function fileIcon(string $filePath,?string $extension = null, ?int $size = 75, ?bool $lazy = false, ?string $twigExtension = null, ?bool $cachebreaker = null): array {
+    public function fileIcon(?string $filePath,?string $extension = null, ?int $size = 75, ?bool $lazy = false, ?string $twigExtension = null, ?bool $cachebreaker = null): array {
         $imageTemplate = null;
 
         if (null === $extension) {

--- a/Twig/FileTypeExtension.php
+++ b/Twig/FileTypeExtension.php
@@ -17,7 +17,7 @@ class FileTypeExtension extends AbstractExtension {
         return $this->fileTypeService->accept($type);
     }
 
-    public function fileIcon(string $filePath, ?string $extension = null, ?int $size = 75): array {
+    public function fileIcon(?string $filePath, ?string $extension = null, ?int $size = 75): array {
         return $this->fileTypeService->fileIcon($filePath, $extension, $size);
     }
 


### PR DESCRIPTION
Hello!
I made this PR due to that bundle was crashing my whole app, because init image form (and data for that field) is setting as null. Then I was getting error like that:

`Artgris\Bundle\FileManagerBundle\Twig\FileTypeExtension::fileIcon(): Argument #1 ($filePath) must be of type string, null given, called in /var/www/html/var/cache/dev/twig/6e/6e495f0b52a3ab1eb72f008012aa93cd.php on line 453`