### PR TITLE
Remove sensio/framework-extra-bundle dependency.

### DIFF
--- a/Tests/Fixtures/App/AppKernel.php
+++ b/Tests/Fixtures/App/AppKernel.php
@@ -16,7 +16,6 @@ class AppKernel extends Kernel
             new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
             new Symfony\Bundle\SecurityBundle\SecurityBundle(),
             new Symfony\Bundle\TwigBundle\TwigBundle(),
-            new Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle(),
         ];
     }
 

--- a/Tests/Fixtures/App/config/config.yml
+++ b/Tests/Fixtures/App/config/config.yml
@@ -26,8 +26,3 @@ framework:
 services:
     logger:
         class: Psr\Log\NullLogger
-
-
-sensio_framework_extra:
-    router:
-        annotations: false

--- a/composer.json
+++ b/composer.json
@@ -17,18 +17,19 @@
   ],
   "require": {
     "php": ">=8.0.2",
-    "sensio/framework-extra-bundle": "^6.1",
+    "doctrine/annotations": "^1.14",
+    "oomphinc/composer-installers-extender": "^2.0",
+    "symfony/asset": "^6.0",
+    "symfony/event-dispatcher": "^6.0",
+    "symfony/expression-language": "^6.0",
+    "symfony/framework-bundle": "^6.0",
+    "symfony/flex": "^2",
+    "symfony/form": "^6.0",
+    "symfony/mime": "^6.0",
     "symfony/translation": "^6.0",
     "symfony/twig-bridge": "^6.0",
     "symfony/twig-bundle": "^6.0",
-    "symfony/form": "^6.0",
-    "symfony/event-dispatcher": "^6.0",
-    "symfony/validator": "^6.0",
-    "symfony/asset": "^6.0",
-    "symfony/mime": "^6.0",
-    "symfony/expression-language": "^6.0",
-    "oomphinc/composer-installers-extender": "^2.0",
-    "symfony/flex": "^2"
+    "symfony/validator": "^6.0"
   },
   "require-dev": {
     "symfony/phpunit-bridge": "^6.0",


### PR DESCRIPTION
Remove deprecated `sensio/framework-extra-bundle` dependency.
See issue #113.
Source: https://github.com/sensiolabs/SensioFrameworkExtraBundle