### PR TITLE
fix: allow to prepend artgris_file_manager

### DIFF
--- a/DependencyInjection/ArtgrisFileManagerExtension.php
+++ b/DependencyInjection/ArtgrisFileManagerExtension.php
@@ -12,13 +12,17 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
  */
 class ArtgrisFileManagerExtension extends Extension
 {
+    public function getConfiguration(array $config, ContainerBuilder $container): Configuration
+    {
+        return new Configuration($container->getParameter('kernel.project_dir'));
+    }
+
     /**
      * {@inheritdoc}
      */
     public function load(array $configs, ContainerBuilder $container): void
     {
-        
-        $configuration = new Configuration($container->getParameter('kernel.project_dir'));
+        $configuration = $this->getConfiguration($configs, $container);
         $config = $this->processConfiguration($configuration, $configs);
 
         $container->setParameter('artgris_file_manager', $config);


### PR DESCRIPTION
- When the Configuration service has dependencies, the "getConfiguration" of the bundle extension must be defined to build it
- Without this, the error "The extension with alias "artgris_file_manager" does not have its getConfiguration() method setup" is triggered by the prepend extension usage