### PR TITLE
Fix symbolic link preview

### DIFF
--- a/Resources/views/views/_list.html.twig
+++ b/Resources/views/views/_list.html.twig
@@ -44,7 +44,7 @@
                 </td>
                 <td>
                     {% block file_preview %}
-                        {{ fileEntity.preview ? fileEntity.preview.html|raw }}
+                        {{ fileEntity.preview.html is defined ? fileEntity.preview.html|raw }}
                     {% endblock %}
                 </td>
                 <td data-value="{{ file.fileName }}" {{ fileEntity.attribut|raw }}>

--- a/Resources/views/views/_thumbnail.html.twig
+++ b/Resources/views/views/_thumbnail.html.twig
@@ -15,7 +15,7 @@
             {% endblock %}
             {% block file_preview %}
                 <div class="thumbnail-img">
-                    {{ fileEntity.preview ? fileEntity.preview.html|raw }}
+                    {{ fileEntity.preview.html is defined ? fileEntity.preview.html|raw }}
                 </div>
             {% endblock %}
             <p {{ fileEntity.attribut|raw }}>

--- a/Service/FileTypeService.php
+++ b/Service/FileTypeService.php
@@ -51,6 +51,9 @@ class FileTypeService {
                 'folder' => '<a  href="'.$href.'">'.$file->getFilename().'</a>',
             ];
         }
+        if ('link' === $type) {
+            return $this->preview($fileManager, new SplFileInfo($file->getRealPath()));
+        }
     }
 
     public function accept($type): bool|string {

--- a/Service/FileTypeService.php
+++ b/Service/FileTypeService.php
@@ -19,7 +19,7 @@ class FileTypeService {
     public function __construct(private RouterInterface $router, private Environment $twig) {
     }
 
-    public function preview(FileManager $fileManager, SplFileInfo $file) {
+    public function preview(FileManager $fileManager, SplFileInfo $file): array {
 
         if ($fileManager->getImagePath()) {
             $filePath = $fileManager->getImagePath().rawurlencode($file->getFilename());
@@ -54,6 +54,8 @@ class FileTypeService {
         if ('link' === $type) {
             return $this->preview($fileManager, new SplFileInfo($file->getRealPath()));
         }
+
+        return [];
     }
 
     public function accept($type): bool|string {


### PR DESCRIPTION
As mentioned in #155, this patch fixes the case when a symbolic link is listed.

It follows the link and calls `preview` recursively with the real path.

The only caution I see is an infiniteloop of link, but this would be due to user error on its link rather than the code itself. 