### PR TITLE
fix: use kernel.project_dir parameter for web_dir default value

### DIFF
--- a/DependencyInjection/ArtgrisFileManagerExtension.php
+++ b/DependencyInjection/ArtgrisFileManagerExtension.php
@@ -12,11 +12,6 @@ use Symfony\Component\DependencyInjection\Extension\Extension;
  */
 class ArtgrisFileManagerExtension extends Extension
 {
-    public function getConfiguration(array $config, ContainerBuilder $container): Configuration
-    {
-        return new Configuration($container->getParameter('kernel.project_dir'));
-    }
-
     /**
      * {@inheritdoc}
      */

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -10,9 +10,6 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  */
 class Configuration implements ConfigurationInterface
 {
-    public function __construct(private string $projectDir) {
-    }
-
     /**
      * {@inheritdoc}
      */
@@ -25,7 +22,7 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->scalarNode('web_dir')
-                    ->defaultValue($this->projectDir."/public")
+                    ->defaultValue('%kernel.project_dir%/public')
                 ->end()
                 ->arrayNode('conf')
                     ->prototype('array')


### PR DESCRIPTION
Since Symfony 7.4, the file `config/reference.php` contains configurations of all bundles : https://symfony.com/blog/new-in-symfony-7-4-better-php-configuration

Using a dynamic value for a default value is not a good thing because the value will change at each container compilation, which results in "useless" modification of the file.

`web_dir` is using the `kernel.project_dir` which can be used with `%` placeholder, the value will be replaced during compilation.